### PR TITLE
Laravel 9 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,10 +11,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.0]
-        laravel: [8.*]
+        php: [8.0, 8.1]
+        laravel: [8.*, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 9.*
+            testbench: 7.*
           - laravel: 8.*
             testbench: ^6.16
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,12 +12,12 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.0, 8.1]
-        laravel: [8.*, 9.*]
+        laravel: [^8.71, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
             testbench: 7.*
-          - laravel: 8.*
+          - laravel: ^8.71
             testbench: ^6.16
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/database": "8.*",
-        "illuminate/support": "8.*"
+        "illuminate/database": "^8.0|^9.0",
+        "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.19",
+        "orchestra/testbench": "^6.19|^7.0",
         "phpunit/phpunit": "^9.5.8",
         "mockery/mockery": "^1.4"
     },


### PR DESCRIPTION
Hello @DarkGhostHunter!

This PR allows the package to be installed in Laravel 9.
Additionally, it updates the test suite for running on PHP 8.1 and Laravel 9.

Note: The minimum required version of Laravel is now 8.71 (because early versions of Laravel 8 don't support PHP 8.1).